### PR TITLE
Update Dropbox Access Method

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,8 +2,6 @@ name: cron
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
   - cron: '1 * * * *'
 jobs:
@@ -15,8 +13,10 @@ jobs:
     - run: npm install
     - shell: bash
       env:
-        DROPBOX_ACCESS_TOKEN: ${{ secrets.DROPBOX_ACCESS_TOKEN }}
+        DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+        DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
+        DROPBOX_REFRESH_TOKEN: ${{ secrets.DROPBOX_REFRESH_TOKEN }}
+        NYT_COOKIE: ${{ secrets.NYT_COOKIE }}
         DROPBOX_NYTC_PATH: ${{ secrets.DROPBOX_NYTC_PATH }}
         DROPBOX_WSJC_PATH: ${{ secrets.DROPBOX_WSJC_PATH }}
-        NYT_COOKIE: ${{ secrets.NYT_COOKIE }}
       run: node main.js

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ Downloads tomorrow's crosswords into a designated Dropbox folder.
 
 ## Instructions:
 1. Fork
-2. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN, DROPBOX_NYTC_PATH, DROPBOX_WSJC_PATH, NYT_COOKIE secrets
-3. Profit!
+2. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, and DROPBOX_REFRESH_TOKEN secrets based on the [instructions](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-2%3A-generate-a-dropbox-refresh-token).
+3. Set NYT_COOKIE secrets by using DevTools to read all cookies from a logged in browser ([document.cookie](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-3%3A-obtain-your-nyt-cookie) is not sufficient as some cookies are [HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly)).
+4. Set DROPBOX_NYTC_PATH and DROPBOX_WSJC_PATH secrets based on your own preferences.
+5. Profit!
 
 ## Credit:
 Adapted from https://nathanbuchar.com/automatically-uploading-the-nyt-crossword-supernote/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Downloads tomorrow's crosswords into a designated Dropbox folder.
 
 ## Instructions:
 1. Fork
-2. Set DROPBOX_ACCESS_TOKEN, DROPBOX_NYTC_PATH, DROPBOX_WSJC_PATH, NYT_COOKIE secrets
+2. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN, DROPBOX_NYTC_PATH, DROPBOX_WSJC_PATH, NYT_COOKIE secrets
 3. Profit!
 
 ## Credit:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Downloads tomorrow's crosswords into a designated Dropbox folder.
 
 ## Instructions:
 1. Fork
-2. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, and DROPBOX_REFRESH_TOKEN secrets based on the [instructions](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-2%3A-generate-a-dropbox-refresh-token).
-3. Set NYT_COOKIE secrets by using DevTools to read all cookies from a logged in browser ([document.cookie](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-3%3A-obtain-your-nyt-cookie) is not sufficient as some cookies are [HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly)).
-4. Set DROPBOX_NYTC_PATH and DROPBOX_WSJC_PATH secrets based on your own preferences.
-5. Profit!
+2. Setup secrets:
+  1. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, and DROPBOX_REFRESH_TOKEN based on the [instructions](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-2%3A-generate-a-dropbox-refresh-token).
+  2. Set NYT_COOKIE by using DevTools to read all cookies from a logged in browser ([document.cookie](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-3%3A-obtain-your-nyt-cookie) is not sufficient as some cookies are [HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly)).
+  3. Set DROPBOX_NYTC_PATH and DROPBOX_WSJC_PATH based on your own preferences.
+3. Profit!
 
 ## Credit:
 Adapted from https://nathanbuchar.com/automatically-uploading-the-nyt-crossword-supernote/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Downloads tomorrow's crosswords into a designated Dropbox folder.
 ## Instructions:
 1. Fork
 2. Setup secrets:
-  1. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, and DROPBOX_REFRESH_TOKEN based on the [instructions](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-2%3A-generate-a-dropbox-refresh-token).
-  2. Set NYT_COOKIE by using DevTools to read all cookies from a logged in browser ([document.cookie](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-3%3A-obtain-your-nyt-cookie) is not sufficient as some cookies are [HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly)).
-  3. Set DROPBOX_NYTC_PATH and DROPBOX_WSJC_PATH based on your own preferences.
+    1. Set DROPBOX_APP_KEY, DROPBOX_APP_SECRET, and DROPBOX_REFRESH_TOKEN based on the [instructions](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-2%3A-generate-a-dropbox-refresh-token).
+    2. Set NYT_COOKIE by using DevTools to read all cookies from a logged in browser ([document.cookie](https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-3%3A-obtain-your-nyt-cookie) is not sufficient as some cookies are [HttpOnly](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#httponly)).
+    3. Set DROPBOX_NYTC_PATH and DROPBOX_WSJC_PATH based on your own preferences.
 3. Profit!
 
 ## Credit:

--- a/main.js
+++ b/main.js
@@ -82,7 +82,7 @@ async function nytc(date) {
     console.log(`Successfully uploaded ${response.result.content_hash}.`);
     return;
   } catch (error) {
-    console.log(`DROPBOX_ACCESS_TOKEN likely expired. Error: ${error}`);
+    console.log(`DROPBOX_REFRESH_TOKEN likely invalid. Error: ${error}`);
     process.exit(1);
   }
 }

--- a/main.js
+++ b/main.js
@@ -5,7 +5,9 @@ const path = require('path');
 const process = require('process');
 
 const dbx = new dropbox.Dropbox({
-  accessToken: process.env.DROPBOX_ACCESS_TOKEN,
+  clientId: process.env.DROPBOX_APP_KEY,
+  clientSecret: process.env.DROPBOX_APP_SECRET,
+  refreshToken: process.env.DROPBOX_REFRESH_TOKEN,
 });
 
 function getNYTC(date) {


### PR DESCRIPTION
Let's use the new instructions at https://www.nathanbuchar.com/how-to-automatically-upload-daily-nyt-crossword-dropbox-2023#step-2%3A-generate-a-dropbox-refresh-token

Closes #2 